### PR TITLE
Deleted timestamp when pulling-to-refresh on LotlistVC

### DIFF
--- a/ParkenDD/LotlistView/LotlistViewController.swift
+++ b/ParkenDD/LotlistView/LotlistViewController.swift
@@ -132,11 +132,6 @@ class LotlistViewController: UITableViewController, UIViewControllerPreviewingDe
             attrs = [NSAttributedStringKey.foregroundColor: UIColor.red]
             drop(L10n.outdatedDataWarning.string, state: .blur(.dark))
         }
-
-        let dateFormatter = DateFormatter(dateFormat: "dd.MM.yyyy HH:mm", timezone: nil)
-        DispatchQueue.main.async {
-            self.refreshControl?.attributedTitle = NSAttributedString(string: "\(L10n.lastUpdated(dateFormatter.string(from: lastUpdated)))", attributes: attrs)
-        }
     }
 
 	/**


### PR DESCRIPTION
Addresses Trello 3.
Very small PR that deletes a few lines of code used to show a timestamp during a pull-to-refresh in the LotlistViewController.